### PR TITLE
Further clarify example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tiny href click handler library.
 ```js
 var nanohref = require('nanohref')
 
+// Handler automatically attached to window.document
 nanohref(function (location) {
   console.log('new location is', location.pathname)
 })


### PR DESCRIPTION
Helped clarify that `nanohref`'s click handler is automatically attached to `window.document` is a root node isn't explicitly defined.