### PR TITLE
Use addEventListener instead of onclick

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function href (cb, root) {
   assert.equal(typeof cb, 'function', 'nanohref: cb must be type function')
   root = root || window.document
 
-  window.onclick = function (e) {
+  window.addEventListener('click', function (e) {
     if ((e.button && e.button !== 0) || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
 
     var node = (function traverse (node) {
@@ -30,5 +30,5 @@ function href (cb, root) {
 
     e.preventDefault()
     cb(node)
-  }
+  })
 }


### PR DESCRIPTION
By using `addEventListener`, we avoid overriding an existing `onclick` handler, or being overridden by a later `onclick` handler.

The only downside I know of to think change is that you lose IE8 support. Wonder if that matters.