### PR TITLE
Fix `noopener` regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 
-var safeExternalLink = /[noopener|noreferrer] [noopener|noreferrer]/
+var safeExternalLink = /(noopener|noreferrer) (noopener|noreferrer)/
 var protocolLink = /^[\w-_]+:/
 
 module.exports = href


### PR DESCRIPTION
This was using `[]` instead of `()`, so it was only comparing the last
character of the first word and the first character of the second word.

False positives were still extremely unlikely, so it wasn't a big
problem.