### PR TITLE
3.0.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ function href (cb, root) {
 
     if (window.location.protocol !== anchor.protocol ||
         window.location.hostname !== anchor.hostname ||
-        window.location.pathname !== anchor.pathname ||
         window.location.port !== anchor.port ||
       anchor.hasAttribute('download') ||
       (anchor.getAttribute('target') === '_blank' &&

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nanohref",
   "description": "Tiny href click handler library",
   "repository": "yoshuawuyts/nanohref",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev -i nanoassert",
     "start": "node .",


### PR DESCRIPTION
This fixes a bug introduced in 3.0.2 where the `window.location.pathname` would never equal `anchor.pathname`, causing click events to incorrectly bubble up.