### PR TITLE
fix: return early if click targets element outside of root node

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function href (cb, root) {
   window.addEventListener('click', function (e) {
     if ((e.button && e.button !== 0) ||
       e.ctrlKey || e.metaKey || e.altKey || e.shiftKey ||
-      e.defaultPrevented) return
+      e.defaultPrevented || !root.contains(e.target)) return
 
     var anchor = (function traverse (node) {
       if (!node || node === root) return


### PR DESCRIPTION
This is related to https://github.com/choojs/choo/issues/704

It looks like clicks outside the given root node would still be handled as the check of

https://github.com/choojs/nanohref/blob/80c11c4fdb1c731aad1b94f4c93b0c386b97c69c/index.js#L22

would never apply until the traversal has reached an anchor element.

Two questions/concerns from my side:

- Does [Node.contains](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains) align with the supported browser range?
- In (the unlikely) case of `root` being an anchor element itself, a click on this element would also be skipped right now. This is the case with and without the fix, yet I am not sure if this is considered ok or should be fixed?